### PR TITLE
Binding all addresses for listening.

### DIFF
--- a/templates/default/gerrit/gerrit.config
+++ b/templates/default/gerrit/gerrit.config
@@ -20,7 +20,7 @@
 	listenAddress = *:<%= node['gerrit']['port'] %>
 [httpd]
 <% if node['gerrit']['proxy'] %>
-	listenUrl = proxy-http<%= node['gerrit']['ssl'] ? 's' : '' %>://127.0.0.1:8080/
+	listenUrl = proxy-http<%= node['gerrit']['ssl'] ? 's' : '' %>://*:8080/
 <% else %>
 	listenUrl = http://*:8080/
 <% end %>


### PR DESCRIPTION
This allows you to access the server externally - on AWS for instance.
