### PR TITLE
Use apache cookbook's value instead of hard-coded port 80

### DIFF
--- a/templates/default/apache/web_app.conf.erb
+++ b/templates/default/apache/web_app.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:<%= node['gerrit']['ssl'] ? '443' : '80' %>>
+<VirtualHost *:<%= node['gerrit']['ssl'] ? '443' : (@params[:server_port] || node['apache']['listen_ports'].first) %>>
   ServerName <%= @params[:server_name] %>
   ServerAlias <% @params[:server_aliases].each do |a| %><%= "#{a}" %> <% end %>
   DocumentRoot <%= @params[:docroot] %>


### PR DESCRIPTION
Setting node['apache']['listen_ports'] to ['1080'] tells the Apache cookbook to listen on port 1080, which is reflected in httpd.conf. This change tells the gerrit site's Apache conf file to behave in the same way.
