### PR TITLE
Remove ssl_certificates cookbook dependency

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,4 @@ site :opscode
 
 metadata
 
-cookbook 'ssl_certificates', github: 'TYPO3-cookbooks/ssl_certificates'
 cookbook 'postgresql', '~> 3.3'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -3,9 +3,6 @@ DEPENDENCIES
     path: .
     metadata: true
   postgresql (~> 3.3)
-  ssl_certificates
-    git: git://github.com/TYPO3-cookbooks/ssl_certificates.git
-    branch: master
 
 GRAPH
   apache2 (1.10.0)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Requirements
 * git
 * maven
 * apache2
-* [ssl_certificates](http://github.com/typo3-cookbooks/ssl_certificates)
 * Optional: [git-daemon](http://github.com/typo3-cookbooks/git-daemon)
 
 Attributes
@@ -56,7 +55,9 @@ connections on ([sshd.listenAddress](http://gerrit-documentation.googlecode.com/
 * `node['gerrit']['canonicalGitUrl']` - The URL under which the repositories are available through the Git protocol ([gerrit.canonicalGitUrl](http://gerrit-documentation.googlecode.com/svn/Documentation/2.5/config-gerrit.html#gerrit.canonicalGitUrl)). Has to include the protocol (`git://`). As Gerrit does _not_ support the Git protocol, such a server has to be managed through another cookbook, e.g. [git-daemon](http://github.com/typo3-cookbooks/git-daemon).
 * `node['gerrit']['proxy']` - Enable Apache2 reverse proxy in front of Gerrit. Defaults to `true`, which makes Gerrit available on port 80.
 * `node['gerrit']['ssl']` - Enable SSL for the reverse proxy. Defaults to `false`.
-* `node['gerrit']['ssl_certificate']`- Makes use of the [ssl_certificates](http://github.com/typo3-cookbooks/ssl_certificates), to use a certain SSL certificate. An entry in the `ssl_certificates` data bag matching the given name must exist. Defaults to `nil`, which results in snakeoil certificates being used.
+* `node['ssl_certificates']['ssl_certfile_path']`- Path to an SSL certfile, to be used if `node['gerrit']['ssl']` is true.  Will default to snakeoil cert if unset.
+* `node['ssl_certificates']['ssl_keyfile_path']`- Path to an SSL keyfile, to be used if `node['gerrit']['ssl']` is true.  Will default to snakeoil key if unset.
+* `node['ssl_certificates']['ssl_cabundle_path'']`- Path to an SSL ca bundle, to be used if `node['gerrit']['ssl']` is true.  Defaults to nil.
 
 SSHD
 ----

--- a/recipes/proxy.rb
+++ b/recipes/proxy.rb
@@ -31,13 +31,14 @@ if node['gerrit']['ssl']
 
   ssl_certfile_path = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
   ssl_keyfile_path  = "/etc/ssl/private/ssl-cert-snakeoil.key"
+  ssl_cabundle_path  = ""
 
   # don't use snakeoil CA, if specified otherwise
-  if node['gerrit']['ssl_certificate']
-    ssl_certificate node['gerrit']['ssl_certificate']
-    ssl_certfile_path = node['ssl_certificates']['path'] + "/" + node['gerrit']['ssl_certificate'] + ".crt"
-    ssl_keyfile_path  = node['ssl_certificates']['path'] + "/" + node['gerrit']['ssl_certificate'] + ".key"
-    ssl_cabundle_path = node['ssl_certificates']['path'] + "/" + node['gerrit']['ssl_certificate'] + ".ca-bundle"
+  if node['ssl_certificates']
+    ssl_certfile_path = node['ssl_certificates']['ssl_certfile_path']
+    ssl_keyfile_path  = node['ssl_certificates']['ssl_keyfile_path']
+    ssl_cabundle_path = node['ssl_certificates']['ssl_cabundle_path'] \
+        if node['ssl_certificates']['ssl_cabundle_path']
   end
 end
 


### PR DESCRIPTION
It's now up to the user to get their certificates onto the target system
however they see fit.

We just need three attributes; 'ssl_keyfile_path', 'ssl_certfile_path',
and optionally 'ssl_cabundle_path'.

Fixes Issue #10
