### PR TITLE
Fix automatic start of the gerrit service

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -217,10 +217,6 @@ link "/etc/init.d/gerrit" do
   to "#{node['gerrit']['install_dir']}/bin/gerrit.sh"
 end
 
-link "/etc/rc3.d/S90gerrit" do
-  to "../init.d/gerrit"
-end
-
 service "gerrit" do
   supports :status => false, :restart => true, :reload => true
   action [ :enable, :start ]


### PR DESCRIPTION
The gerrit service was not properly registered for starting at boot
time.  After a reboot, it would not start.

The recipe created a manual symlink from rc3.d to init.d.  But the
default run level on Debian is 2, so this would have no effect.

The action :enable of service "gerrit" internally calls

```
update-rc.d gerrit defaults
```

but this notices the symlink in rc3.d and does nothing, assuming that
the administrator wanted to manually override the configuration.

The fix is to remove the creation of the symlink from rc3.d to init.d
and let the service resource to its thing.
