### PR TITLE
[TASK] Remove build_essential resource

### DIFF
--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -18,11 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-## Otherwise the chef_gem[mysql] fails to install
-build_essential 'install_packages' do
-  compile_time true
-end
-
 include_recipe "mysql::client"
 include_recipe "mysql::server"
 include_recipe "database::mysql"


### PR DESCRIPTION
This resource isn't available in newer versions of the build-essential cookbook
and it seems that our cookbook runs fine without including it.