### PR TITLE
[TASK] gerrit_replication resource: Override hostname

### DIFF
--- a/test/fixtures/cookbooks/gerrit_test/recipes/replication.rb
+++ b/test/fixtures/cookbooks/gerrit_test/recipes/replication.rb
@@ -6,5 +6,5 @@ end
 gerrit_replication 'example.com' do
   uri 'git@example.com:test'
   ssh_key '123456'
-  hostname 'localhost'
+  hostname 'gitlab.com'
 end

--- a/test/fixtures/cookbooks/gerrit_test/recipes/replication.rb
+++ b/test/fixtures/cookbooks/gerrit_test/recipes/replication.rb
@@ -2,3 +2,9 @@ gerrit_replication 'github.com' do
   uri 'git@github.com:TYPO3/TYPO3.CMS'
   ssh_key '123456'
 end
+
+gerrit_replication 'example.com' do
+  uri 'git@example.com:test'
+  ssh_key '123456'
+  hostname 'localhost'
+end

--- a/test/integration/db-h2/inspec/gerrit_spec.rb
+++ b/test/integration/db-h2/inspec/gerrit_spec.rb
@@ -78,5 +78,13 @@ control 'gerrit-4' do
   describe file('/var/gerrit/.ssh/known_hosts') do
     it { should exist }
     its('content') { should include 'github.com' }
+    its('content') { should include 'localhost' }
+    its('content') { should_not include 'example.com' }
+  end
+
+  describe file('/var/gerrit/.ssh/config') do
+    it { should exist }
+    # test that ssh_config is passed through
+    its('content') { should include 'Hostname localhost'}
   end
 end

--- a/test/integration/db-h2/inspec/gerrit_spec.rb
+++ b/test/integration/db-h2/inspec/gerrit_spec.rb
@@ -78,13 +78,14 @@ control 'gerrit-4' do
   describe file('/var/gerrit/.ssh/known_hosts') do
     it { should exist }
     its('content') { should include 'github.com' }
-    its('content') { should include 'localhost' }
+    # test that hostname override is passed through
+    its('content') { should include 'gitlab.com' }
     its('content') { should_not include 'example.com' }
   end
 
   describe file('/var/gerrit/.ssh/config') do
     it { should exist }
-    # test that ssh_config is passed through
-    its('content') { should include 'Hostname localhost'}
+    # test that hostname override is passed through
+    its('content') { should include 'Hostname gitlab.com'}
   end
 end


### PR DESCRIPTION
We need a way to override the hostname of a replication target to the
interal hostname (for {git,forge}.typo3.org).
Using .ssh/config's Hostname option is one of many, how we could achieve this..