### PR TITLE
[BUGFIX] Stop gerrit earlier during update

### DIFF
--- a/recipes/_deploy.rb
+++ b/recipes/_deploy.rb
@@ -11,9 +11,9 @@ remote_file war_path do
   owner node['gerrit']['user']
   source node['gerrit']['war']['download_url'] % {version: node['gerrit']['version']}
   # checksum node['gerrit']['war']['checksum'][node['gerrit']['version']]
-  notifies :run, "execute[gerrit-init]", :immediately
   # important during upgrade
-  notifies :stop, "service[gerrit]", :immediately
+  notifies :stop, "service[gerrit-without-readiness-check]", :immediately
+  notifies :run, "execute[gerrit-init]", :immediately
   action :create_if_missing
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ if node['gerrit']['batch_admin_user']['enabled']
 end
 
 # we have to split up the service because of the immediate notification
-service "gerrit-definition" do
+service "gerrit-without-readiness-check" do
   service_name "gerrit"
   supports :status => false, :restart => true, :reload => true
   action :enable


### PR DESCRIPTION
It seems that in newer versions of Gerrit, the `gerrit init` command also does something related
to indexes. As previously, we were stopping Gerrit *after* running `gerrit init` (which probably never
made sense..), it fails during upgrades with the following error:

> Lock held by another program:
> /var/gerrit/review/index/accounts_0004/write.lock

To fix this, stop gerrit as very first stop after deploying a new .war file.