### PR TITLE
[TASK] Use Corretto 8 instead of Oracle

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,8 +83,6 @@ default['gerrit']['peer_keys']['enabled'] = false
 default['gerrit']['peer_keys']['public'] = ""
 default['gerrit']['peer_keys']['private'] = ""
 
-# Gerrit 2.9 requires Java 7
-default['java']['jdk_version'] = "8"
-default['java']['install_flavor'] = "oracle"
-default['java']['oracle']['accept_oracle_download_terms'] = true
-
+# Gerrit >= 2.14 requires Java 8
+default['java']['jdk_version'] = '8'
+default['java']['install_flavor'] = 'corretto'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -83,7 +83,7 @@ module Gerrit
     end
 
     def wait_until_ready!(endpoint, status)
-      timeout = 60
+      timeout = 300
       Timeout.timeout(timeout, ConnectTimeout) do
         begin
           open(endpoint)
@@ -97,7 +97,7 @@ module Gerrit
           return if e.message =~ /^#{status}/
 
           Chef::Log.debug("Gerrit is not accepting requests - #{e.message}")
-          sleep(0.5)
+          sleep(2)
           retry
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,9 +8,13 @@ version          IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0
 
 depends "apache2"
 depends "build-essential"
+depends 'curl', '~> 2.0.4'
 depends "database", "= 1.3.12"
 depends "mysql", "= 1.3.0"
-depends "java"
+depends "java", ">= 4.1.0"
 depends "git"
 depends "ssh"
 depends "systemd", "< 3.0"
+
+# For compatibility with Chef 12
+depends "seven_zip",    "< 3.0.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 #
 
 include_recipe "git"
+include_recipe "curl"
 include_recipe "java"
 # used later on to restart after JRE update
 include_recipe "java::notify"
@@ -48,7 +49,7 @@ service "gerrit" do
   action :start
   subscribes :restart, 'log[jdk-version-changed]', :delayed
   # proceed only after finished restart
-  notifies :run, 'ruby_block[wait_until_ready]', :immediately
+  notifies :run, 'ruby_block[wait_until_ready]', :delayed
 end
 
 ruby_block "wait_until_ready" do


### PR DESCRIPTION
Corretto allows to use a OpenJDK 8 and Oracle proves to be an unreliable
download source and problematic due to the new licensing.

As startup takes longer than when using Oracle timeouts have been raised

For some reason curl is no longer included in postgres and h2 builds,
therefore an according general dependency has been added.

The gerrit cookbook requires build-essential which requires mingw which
requires seven_zip (mingw and seven_zip are for windows but well..). The
current seven_zip 3.x requires Chef 13 but we run Chef 12. Pin seven_zip
to <3.0.0 to fix this.